### PR TITLE
Fix failing workflows

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
      dev: flake8
      dev,doctests: sphinx>=1.5
      dev,doctests: guzzle-sphinx-theme
+     examples: jupyter
 commands =
      tests: python run-tests.py --unit --folder all
      unit: python run-tests.py --unit


### PR DESCRIPTION
Fix failing workflows by adding jupyter as dependency for examples, and allow for Python 3.10 and 3.11